### PR TITLE
fix: deduplicate security headers, add Cache-Control to 10 uncached admin API routes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -113,6 +113,10 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        // Security headers that are NOT set by middleware (unique to next.config).
+        // X-Frame-Options, X-Content-Type-Options, Referrer-Policy, X-XSS-Protection,
+        // and CSP are set in middleware.ts — do NOT duplicate them here to avoid
+        // conflicting values (e.g. Referrer-Policy was previously different).
         source: '/(.*)',
         headers: [
           {
@@ -123,18 +127,6 @@ const nextConfig: NextConfig = {
             key: 'Strict-Transport-Security',
             value: 'max-age=63072000; includeSubDomains; preload'
           },
-          {
-            key: 'X-Frame-Options',
-            value: 'DENY'
-          },
-          {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff'
-          },
-          {
-            key: 'Referrer-Policy',
-            value: 'origin-when-cross-origin'
-          }
         ]
       },
       {

--- a/src/app/api/admin/analytics/curator-activity/route.ts
+++ b/src/app/api/admin/analytics/curator-activity/route.ts
@@ -16,7 +16,11 @@ export async function GET(_request: NextRequest) {
     // Get curator activity summary
     const activityData = await AdminAnalyticsQueries.getCuratorActivity();
 
-    return NextResponse.json({ data: activityData });
+    return NextResponse.json({ data: activityData }, {
+      headers: {
+        'Cache-Control': 'private, max-age=60, stale-while-revalidate=120',
+      },
+    });
   } catch (error) {
     console.error('Failed to get curator activity:', error);
     return NextResponse.json(

--- a/src/app/api/admin/analytics/plant-trends/route.ts
+++ b/src/app/api/admin/analytics/plant-trends/route.ts
@@ -16,7 +16,11 @@ export async function GET(_request: NextRequest) {
     // Get plant submission trends for the last 30 days
     const trendData = await AdminAnalyticsQueries.getPlantSubmissionTrends();
 
-    return NextResponse.json({ data: trendData });
+    return NextResponse.json({ data: trendData }, {
+      headers: {
+        'Cache-Control': 'private, max-age=60, stale-while-revalidate=120',
+      },
+    });
   } catch (error) {
     console.error('Failed to get plant submission trends:', error);
     return NextResponse.json(

--- a/src/app/api/admin/analytics/system-alerts/route.ts
+++ b/src/app/api/admin/analytics/system-alerts/route.ts
@@ -16,7 +16,11 @@ export async function GET(_request: NextRequest) {
     // Get system alerts
     const alerts = await AdminAnalyticsQueries.getSystemAlerts();
 
-    return NextResponse.json({ data: alerts });
+    return NextResponse.json({ data: alerts }, {
+      headers: {
+        'Cache-Control': 'private, max-age=60, stale-while-revalidate=120',
+      },
+    });
   } catch (error) {
     console.error('Failed to get system alerts:', error);
     return NextResponse.json(

--- a/src/app/api/admin/analytics/top-families/route.ts
+++ b/src/app/api/admin/analytics/top-families/route.ts
@@ -26,7 +26,11 @@ export async function GET(request: NextRequest) {
     // Get top plant families by usage
     const familyData = await AdminAnalyticsQueries.getTopPlantFamilies(limit);
 
-    return NextResponse.json({ data: familyData });
+    return NextResponse.json({ data: familyData }, {
+      headers: {
+        'Cache-Control': 'private, max-age=60, stale-while-revalidate=120',
+      },
+    });
   } catch (error) {
     console.error('Failed to get top plant families:', error);
     

--- a/src/app/api/admin/analytics/user-growth/route.ts
+++ b/src/app/api/admin/analytics/user-growth/route.ts
@@ -16,7 +16,11 @@ export async function GET(_request: NextRequest) {
     // Get user growth data for the last 30 days
     const growthData = await AdminAnalyticsQueries.getUserGrowthData();
 
-    return NextResponse.json({ data: growthData });
+    return NextResponse.json({ data: growthData }, {
+      headers: {
+        'Cache-Control': 'private, max-age=60, stale-while-revalidate=120',
+      },
+    });
   } catch (error) {
     console.error('Failed to get user growth data:', error);
     return NextResponse.json(

--- a/src/app/api/admin/dashboard-stats/route.ts
+++ b/src/app/api/admin/dashboard-stats/route.ts
@@ -16,7 +16,11 @@ export async function GET(_request: NextRequest) {
     // Get dashboard statistics
     const stats = await AdminAnalyticsQueries.getDashboardStats();
 
-    return NextResponse.json(stats);
+    return NextResponse.json(stats, {
+      headers: {
+        'Cache-Control': 'private, max-age=30, stale-while-revalidate=60',
+      },
+    });
   } catch (error) {
     console.error('Failed to get dashboard stats:', error);
     return NextResponse.json(

--- a/src/app/api/admin/plants/route.ts
+++ b/src/app/api/admin/plants/route.ts
@@ -48,6 +48,10 @@ export async function GET(request: NextRequest) {
       page,
       pageSize,
       totalPages: Math.ceil(totalCount / pageSize),
+    }, {
+      headers: {
+        'Cache-Control': 'private, max-age=15, stale-while-revalidate=60',
+      },
     });
   } catch (error) {
     console.error('Failed to get admin plants:', error);

--- a/src/app/api/admin/plants/taxonomy-options/route.ts
+++ b/src/app/api/admin/plants/taxonomy-options/route.ts
@@ -10,7 +10,12 @@ export async function GET(_request: NextRequest) {
 
     const taxonomyOptions = await AdminPlantQueries.getTaxonomyOptions();
 
-    return NextResponse.json(taxonomyOptions);
+    return NextResponse.json(taxonomyOptions, {
+      headers: {
+        // Taxonomy options change infrequently — cache for 5 minutes
+        'Cache-Control': 'private, max-age=300, stale-while-revalidate=600',
+      },
+    });
   } catch (error) {
     console.error('Failed to get taxonomy options:', error);
     return NextResponse.json(

--- a/src/app/api/admin/taxonomy/route.ts
+++ b/src/app/api/admin/taxonomy/route.ts
@@ -77,6 +77,10 @@ export async function GET(request: NextRequest) {
       stats,
       page: validatedParams.page,
       pageSize: validatedParams.pageSize,
+    }, {
+      headers: {
+        'Cache-Control': 'private, max-age=60, stale-while-revalidate=120',
+      },
     });
   } catch (error) {
     console.error('Failed to get taxonomy hierarchy:', error);

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -63,7 +63,11 @@ export async function GET(request: NextRequest) {
       resultCount: result.users.length,
     });
     
-    return NextResponse.json(result);
+    return NextResponse.json(result, {
+      headers: {
+        'Cache-Control': 'private, max-age=15, stale-while-revalidate=60',
+      },
+    });
   } catch (error) {
     console.error('Failed to get users:', error);
     


### PR DESCRIPTION
## What Changed

### 🔒 Security Header Deduplication
Security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy) were being set in **both** `next.config.ts` and `middleware.ts`, with conflicting values:
- `next.config.ts`: `Referrer-Policy: origin-when-cross-origin`
- `middleware.ts`: `Referrer-Policy: strict-origin-when-cross-origin` (stricter)

Removed the duplicates from `next.config.ts` — middleware is the canonical source for security headers. Kept `X-DNS-Prefetch-Control` and `Strict-Transport-Security` in next.config since they're not set in middleware.

### ⚡ Cache-Control for Admin API Routes
Added `Cache-Control` headers to 10 admin/analytics GET endpoints that were previously uncached, reducing unnecessary database queries on repeated loads:

| Route | Cache Duration |
|-------|---------------|
| `/api/admin/dashboard-stats` | 30s + 60s SWR |
| `/api/admin/plants` | 15s + 60s SWR |
| `/api/admin/plants/taxonomy-options` | 5min + 10min SWR |
| `/api/admin/taxonomy` | 60s + 120s SWR |
| `/api/admin/users` | 15s + 60s SWR |
| `/api/admin/analytics/*` (5 routes) | 60s + 120s SWR |

All use `private` directive (authenticated content only).

## Why
- Conflicting security headers could cause browsers to pick the weaker policy
- Uncached admin routes hit the database on every request, even when data hasn't changed