### PR TITLE
fix: live care badge in BottomNav, consistent cache invalidation

### DIFF
--- a/src/__tests__/integration/navigation-flows.test.tsx
+++ b/src/__tests__/integration/navigation-flows.test.tsx
@@ -177,34 +177,45 @@ describe('Navigation Integration Flows', () => {
   });
 
   describe('Notification Badge Integration', () => {
-    it('should display care notification badges', () => {
+    it('should display care notification badges from dashboard stats', async () => {
+      mockApiResponses({
+        '/api/auth/curator-status': { isCurator: false },
+        '/api/admin/pending-count': { count: 0 },
+        '/api/dashboard': { overdueCount: 4, careDueToday: 3 },
+      });
+
       renderWithProviders(
-        <BottomNavigation careNotificationCount={7} />, 
+        <BottomNavigation />, 
         { route: '/dashboard' }
       );
 
-      // Should show care badge
-      expect(screen.getByRole('status', { name: /7 notifications/i })).toBeInTheDocument();
-      expect(screen.getByRole('status', { name: /7 notifications/i })).toHaveTextContent('7');
+      // Wait for dashboard stats to load
+      await waitFor(() => {
+        expect(screen.getByRole('status', { name: /7 notifications/i })).toBeInTheDocument();
+        expect(screen.getByRole('status', { name: /7 notifications/i })).toHaveTextContent('7');
+      });
     });
 
     it('should handle badge overflow correctly', async () => {
       mockApiResponses({
         '/api/auth/curator-status': { isCurator: true },
         '/api/admin/pending-count': { count: 150 },
+        '/api/dashboard': { overdueCount: 120, careDueToday: 80 },
       });
 
       const { user } = renderWithProviders(
-        <BottomNavigation careNotificationCount={200} />, 
+        <BottomNavigation />, 
         { route: '/dashboard' }
       );
 
-      // Care badge should show 99+
-      expect(screen.getByRole('status', { name: /200 notifications/i })).toHaveTextContent('99+');
+      // Wait for dashboard stats to load, then care badge should show 99+
+      await waitFor(() => {
+        expect(screen.getByRole('status', { name: /200 notifications/i })).toHaveTextContent('99+');
+      });
 
       // Wait for admin status to load
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith('/api/auth/curator-status');
+        expect(global.fetch).toHaveBeenCalledWith('/api/auth/curator-status', expect.anything());
       }, { timeout: 3000 });
 
       // Open overflow menu to see admin badge

--- a/src/app/dashboard/plants/PlantsPageClient.tsx
+++ b/src/app/dashboard/plants/PlantsPageClient.tsx
@@ -28,6 +28,7 @@ export default function PlantsPageClient({ userId }: PlantsPageClientProps) {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ['plant-instances-enhanced'], exact: false }),
       queryClient.invalidateQueries({ queryKey: ['care-dashboard'], exact: false }),
+      queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] }),
     ]);
   }, [queryClient]);
 

--- a/src/components/navigation/BottomNavigation.tsx
+++ b/src/components/navigation/BottomNavigation.tsx
@@ -16,11 +16,12 @@ interface NavigationItem {
   requiresCurator?: boolean;
 }
 
-interface BottomNavigationProps {
-  careNotificationCount?: number;
+interface DashboardStats {
+  overdueCount: number;
+  careDueToday: number;
 }
 
-export default function BottomNavigation({ careNotificationCount = 0 }: BottomNavigationProps) {
+export default function BottomNavigation() {
   const pathname = usePathname();
   const { triggerHaptic } = useHapticFeedback();
   const [pressedItem, setPressedItem] = useState<string | null>(null);
@@ -40,6 +41,23 @@ export default function BottomNavigation({ careNotificationCount = 0 }: BottomNa
   });
 
   const isCurator = curatorData?.isCurator ?? false;
+
+  // Fetch care notification count — shares cache with DashboardClient (same queryKey)
+  // This gives BottomNav a live badge count without an extra API call when the
+  // dashboard has already been visited in this session.
+  const { data: dashboardStats } = useQuery({
+    queryKey: ['dashboard-stats'],
+    queryFn: async () => {
+      const response = await apiFetch('/api/dashboard');
+      if (!response.ok) return { overdueCount: 0, careDueToday: 0 } as DashboardStats;
+      return response.json() as Promise<DashboardStats>;
+    },
+    staleTime: 1000 * 60 * 2, // 2 minutes — avoid extra fetches on nav changes
+    gcTime: 1000 * 60 * 5,
+    retry: 1,
+  });
+
+  const careNotificationCount = (dashboardStats?.overdueCount ?? 0) + (dashboardStats?.careDueToday ?? 0);
 
   // Fetch pending approval count — only when user is a curator
   const { data: pendingData } = useQuery({

--- a/src/components/navigation/__tests__/BottomNavigation.test.tsx
+++ b/src/components/navigation/__tests__/BottomNavigation.test.tsx
@@ -13,10 +13,11 @@ describe('BottomNavigation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     
-    // Mock API responses
+    // Mock API responses — include dashboard stats for care badge
     mockApiResponses({
       '/api/auth/curator-status': { isCurator: false },
       '/api/admin/pending-count': { count: 0 },
+      '/api/dashboard': { overdueCount: 0, careDueToday: 0 },
     });
   });
 
@@ -112,29 +113,58 @@ describe('BottomNavigation', () => {
   });
 
   describe('Badge Notifications', () => {
-    it('should display care notification badge', () => {
-      renderWithProviders(<BottomNavigation careNotificationCount={5} />, { route: '/dashboard' });
+    it('should display care notification badge from dashboard stats', async () => {
+      mockApiResponses({
+        '/api/auth/curator-status': { isCurator: false },
+        '/api/admin/pending-count': { count: 0 },
+        '/api/dashboard': { overdueCount: 3, careDueToday: 2 },
+      });
 
-      const careLink = screen.getByRole('link', { name: /navigate to care \(5 notifications\)/i });
-      expect(careLink).toBeInTheDocument();
+      renderWithProviders(<BottomNavigation />, { route: '/dashboard' });
+
+      // Wait for dashboard stats to load
+      await waitFor(() => {
+        const careLink = screen.getByRole('link', { name: /navigate to care \(5 notifications\)/i });
+        expect(careLink).toBeInTheDocument();
+      });
       
       const badge = screen.getByRole('status', { name: /5 notifications/i });
       expect(badge).toBeInTheDocument();
       expect(badge).toHaveTextContent('5');
     });
 
-    it('should display 99+ for large notification counts', () => {
-      renderWithProviders(<BottomNavigation careNotificationCount={150} />, { route: '/dashboard' });
+    it('should display 99+ for large notification counts', async () => {
+      mockApiResponses({
+        '/api/auth/curator-status': { isCurator: false },
+        '/api/admin/pending-count': { count: 0 },
+        '/api/dashboard': { overdueCount: 100, careDueToday: 50 },
+      });
 
-      const badge = screen.getByRole('status', { name: /150 notifications/i });
-      expect(badge).toHaveTextContent('99+');
+      renderWithProviders(<BottomNavigation />, { route: '/dashboard' });
+
+      await waitFor(() => {
+        const badge = screen.getByRole('status', { name: /150 notifications/i });
+        expect(badge).toHaveTextContent('99+');
+      });
     });
 
-    it('should not display badge when count is zero', () => {
-      renderWithProviders(<BottomNavigation careNotificationCount={0} />, { route: '/dashboard' });
+    it('should not display badge when count is zero', async () => {
+      mockApiResponses({
+        '/api/auth/curator-status': { isCurator: false },
+        '/api/admin/pending-count': { count: 0 },
+        '/api/dashboard': { overdueCount: 0, careDueToday: 0 },
+      });
+
+      renderWithProviders(<BottomNavigation />, { route: '/dashboard' });
+
+      // Wait for the query to settle
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith('/api/dashboard', expect.anything());
+      });
 
       const careLink = screen.getByRole('link', { name: /navigate to care/i });
       expect(careLink).toBeInTheDocument();
+      // No status badges should be present (no care or admin badges)
       expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });
 
@@ -142,6 +172,7 @@ describe('BottomNavigation', () => {
       mockApiResponses({
         '/api/auth/curator-status': { isCurator: true },
         '/api/admin/pending-count': { count: 7 },
+        '/api/dashboard': { overdueCount: 0, careDueToday: 0 },
       });
 
       const { user } = renderWithProviders(<BottomNavigation />, { route: '/dashboard' });
@@ -274,12 +305,20 @@ describe('BottomNavigation', () => {
   });
 
   describe('Accessibility', () => {
-    it('should have proper ARIA labels for navigation links', () => {
-      renderWithProviders(<BottomNavigation careNotificationCount={3} />, { route: '/dashboard' });
+    it('should have proper ARIA labels for navigation links with care badge', async () => {
+      mockApiResponses({
+        '/api/auth/curator-status': { isCurator: false },
+        '/api/admin/pending-count': { count: 0 },
+        '/api/dashboard': { overdueCount: 2, careDueToday: 1 },
+      });
 
-      const careLink = screen.getByRole('link', { name: /navigate to care \(3 notifications\)/i });
-      expect(careLink).toHaveAttribute('aria-label', 'Navigate to Care (3 notifications)');
-      expect(careLink).toHaveAttribute('title', 'Navigate to Care (3 notifications)');
+      renderWithProviders(<BottomNavigation />, { route: '/dashboard' });
+
+      await waitFor(() => {
+        const careLink = screen.getByRole('link', { name: /navigate to care \(3 notifications\)/i });
+        expect(careLink).toHaveAttribute('aria-label', 'Navigate to Care (3 notifications)');
+        expect(careLink).toHaveAttribute('title', 'Navigate to Care (3 notifications)');
+      });
     });
 
     it('should have proper ARIA attributes for overflow menu', async () => {
@@ -293,12 +332,20 @@ describe('BottomNavigation', () => {
       expect(moreButton).toHaveAttribute('aria-expanded', 'true');
     });
 
-    it('should have proper role attributes for badges', () => {
-      renderWithProviders(<BottomNavigation careNotificationCount={5} />, { route: '/dashboard' });
+    it('should have proper role attributes for badges', async () => {
+      mockApiResponses({
+        '/api/auth/curator-status': { isCurator: false },
+        '/api/admin/pending-count': { count: 0 },
+        '/api/dashboard': { overdueCount: 3, careDueToday: 2 },
+      });
 
-      const badge = screen.getByRole('status', { name: /5 notifications/i });
-      expect(badge).toHaveAttribute('role', 'status');
-      expect(badge).toHaveAttribute('aria-label', '5 notifications');
+      renderWithProviders(<BottomNavigation />, { route: '/dashboard' });
+
+      await waitFor(() => {
+        const badge = screen.getByRole('status', { name: /5 notifications/i });
+        expect(badge).toHaveAttribute('role', 'status');
+        expect(badge).toHaveAttribute('aria-label', '5 notifications');
+      });
     });
 
     it('should hide decorative icons from screen readers', () => {

--- a/src/components/plants/PlantDetailModal.tsx
+++ b/src/components/plants/PlantDetailModal.tsx
@@ -95,7 +95,9 @@ export default function PlantDetailModal({
       // Refetch plant data and invalidate related queries
       refetch();
       queryClient.invalidateQueries({ queryKey: ['plant-instances'] });
+      queryClient.invalidateQueries({ queryKey: ['plant-instances-enhanced'] });
       queryClient.invalidateQueries({ queryKey: ['care-dashboard'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] });
     },
     onError: (error) => {
       console.error('Quick care mutation failed:', error);

--- a/src/test-utils/mocks/component-mocks.tsx
+++ b/src/test-utils/mocks/component-mocks.tsx
@@ -787,7 +787,7 @@ export const navigationComponentMocks = {
         {
           'data-testid': 'bottom-navigation',
           'data-active-route': props.activeRoute,
-          'data-care-notifications': props.careNotificationCount,
+          'data-care-notifications': 0,
         },
         React.createElement('a', { href: '/dashboard' }, 'Dashboard'),
         React.createElement('a', { href: '/plants' }, 'Plants'),


### PR DESCRIPTION
## What Changed

### 🐛 Bug Fix: Care Badge Always Showed 0
The BottomNavigation component accepted a `careNotificationCount` prop for its care badge, but the DashboardLayout never passed it — the badge was perpetually stuck at 0.

**Fix:** BottomNavigation now self-sufficiently fetches the overdue + due-today count from the `dashboard-stats` React Query cache (same query key as DashboardClient). When the user has already visited the dashboard, no extra API call is made. Otherwise, a lightweight fetch fills the cache.

### 🔄 Consistent Cache Invalidation
After logging care from different surfaces, some query caches weren't being invalidated:

- **PlantDetailModal** quick care → now also invalidates `dashboard-stats` and `plant-instances-enhanced`
- **PlantsPageClient** quick care / bulk actions → now also invalidates `dashboard-stats`

This means the BottomNav badge, dashboard stats, and plant grid all update consistently no matter where care is logged.

### 🧪 Tests Updated
All BottomNavigation and integration tests updated to mock `/api/dashboard` instead of passing the now-removed `careNotificationCount` prop.