### PR TITLE
refactor: shared curator hook, S3Image care timeline, dead prop cleanup (#192)

### DIFF
--- a/src/app/dashboard/DashboardClient.tsx
+++ b/src/app/dashboard/DashboardClient.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 import LogoutButton from '@/components/auth/LogoutButton';
 import { apiFetch, ApiError } from '@/lib/api-client';
+import { useCuratorStatus } from '@/hooks/useCuratorStatus';
 import type { DashboardStats } from '@/app/api/dashboard/route';
 
 // Lazy load calendar — only needed when user has fertilizer events
@@ -20,18 +21,8 @@ interface DashboardClientProps {
 }
 
 export default function DashboardClient({ user }: DashboardClientProps) {
-  // Check curator status via useQuery for proper caching and deduplication
-  const { data: curatorData } = useQuery({
-    queryKey: ['curator-status'],
-    queryFn: async () => {
-      const response = await apiFetch('/api/auth/curator-status');
-      if (!response.ok) return { isCurator: false };
-      return response.json() as Promise<{ isCurator: boolean }>;
-    },
-    staleTime: 1000 * 60 * 30, // 30 minutes — curator status rarely changes
-  });
-
-  const isCurator = curatorData?.isCurator ?? false;
+  // Shared hook — deduplicates the ['curator-status'] query across all consumers
+  const { isCurator } = useCuratorStatus();
 
   // Fetch dashboard stats
   const { data: stats, isLoading } = useQuery({

--- a/src/components/care/CareHistoryTimeline.tsx
+++ b/src/components/care/CareHistoryTimeline.tsx
@@ -2,14 +2,13 @@
 
 import { memo } from 'react';
 import Image from 'next/image';
+import S3Image from '@/components/shared/S3Image';
 import type { EnhancedCareHistory } from '@/lib/types/care-types';
-import type { EnhancedPlantInstance } from '@/lib/types/plant-instance-types';
 import { careHelpers } from '@/lib/types/care-types';
+import { shouldUnoptimizeImage } from '@/lib/image-loader';
 
 interface CareHistoryTimelineProps {
   careHistory: EnhancedCareHistory[];
-  /** @deprecated Unused — kept for backward compatibility. */
-  plantInstance?: EnhancedPlantInstance;
   limit?: number;
   showPlantName?: boolean;
 }
@@ -107,22 +106,37 @@ export default memo(function CareHistoryTimeline({
                     )}
                   </div>
 
-                  {/* Images */}
-                  {care.images && care.images.length > 0 && (
+                  {/* Images — prefer S3 keys (signed-cookie auth) over legacy URLs */}
+                  {((care.s3ImageKeys && care.s3ImageKeys.length > 0) || (care.images && care.images.length > 0)) && (
                     <div className="flex space-x-2 mt-3">
-                      {care.images.slice(0, 3).map((image, imgIndex) => (
-                        <Image
-                          key={imgIndex}
-                          src={image}
-                          alt={`Care photo ${imgIndex + 1}`}
-                          width={48}
-                          height={48}
-                          className="w-12 h-12 rounded-lg object-cover border border-gray-200"
-                        />
-                      ))}
-                      {care.images.length > 3 && (
-                        <div key="more-images" className="w-12 h-12 rounded-lg bg-gray-100 border border-gray-200 flex items-center justify-center">
-                          <span className="text-xs text-gray-500">+{care.images.length - 3}</span>
+                      {care.s3ImageKeys && care.s3ImageKeys.length > 0
+                        ? care.s3ImageKeys.slice(0, 3).map((s3Key, imgIndex) => (
+                            <div key={s3Key} className="w-12 h-12 rounded-lg overflow-hidden border border-gray-200 relative flex-shrink-0">
+                              <S3Image
+                                s3Key={s3Key}
+                                alt={`Care photo ${imgIndex + 1}`}
+                                fill
+                                className="object-cover"
+                                thumbnailSize="tiny"
+                                sizes="48px"
+                              />
+                            </div>
+                          ))
+                        : care.images!.slice(0, 3).map((image, imgIndex) => (
+                            <Image
+                              key={imgIndex}
+                              src={image}
+                              alt={`Care photo ${imgIndex + 1}`}
+                              width={48}
+                              height={48}
+                              className="w-12 h-12 rounded-lg object-cover border border-gray-200"
+                              unoptimized={shouldUnoptimizeImage(image)}
+                            />
+                          ))
+                      }
+                      {((care.s3ImageKeys?.length ?? 0) > 3 || (care.images?.length ?? 0) > 3) && (
+                        <div key="more-images" className="w-12 h-12 rounded-lg bg-gray-100 border border-gray-200 flex items-center justify-center flex-shrink-0">
+                          <span className="text-xs text-gray-500">+{((care.s3ImageKeys?.length ?? care.images?.length ?? 0) - 3)}</span>
                         </div>
                       )}
                     </div>

--- a/src/components/navigation/BottomNavigation.tsx
+++ b/src/components/navigation/BottomNavigation.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/api-client';
 import { useHapticFeedback } from '@/hooks/useHapticFeedback';
+import { useCuratorStatus } from '@/hooks/useCuratorStatus';
 import { useState, useEffect, useCallback } from 'react';
 
 interface NavigationItem {
@@ -27,20 +28,8 @@ export default function BottomNavigation() {
   const [pressedItem, setPressedItem] = useState<string | null>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  // Check curator status — shared cache with DashboardClient (same queryKey)
-  const { data: curatorData } = useQuery({
-    queryKey: ['curator-status'],
-    queryFn: async () => {
-      const response = await apiFetch('/api/auth/curator-status');
-      if (!response.ok) return { isCurator: false };
-      return response.json() as Promise<{ isCurator: boolean }>;
-    },
-    staleTime: 1000 * 60 * 30, // 30 minutes — curator status rarely changes
-    gcTime: 1000 * 60 * 30,
-    retry: 1,
-  });
-
-  const isCurator = curatorData?.isCurator ?? false;
+  // Shared hook — deduplicates the ['curator-status'] query across all consumers
+  const { isCurator } = useCuratorStatus();
 
   // Fetch care notification count — shares cache with DashboardClient (same queryKey)
   // This gives BottomNav a live badge count without an extra API call when the

--- a/src/components/plants/PlantDetailModal.tsx
+++ b/src/components/plants/PlantDetailModal.tsx
@@ -221,7 +221,6 @@ export default function PlantDetailModal({
                 {activeTab === 'care' && (
                   <CareHistoryTimeline 
                     careHistory={data.careHistory}
-                    plantInstance={data.plant}
                   />
                 )}
                 


### PR DESCRIPTION
## Changes

### 1. Deduplicate curator status queries
`BottomNavigation` and `DashboardClient` both had inline `useQuery` calls for `['curator-status']` with duplicated config. The `useCuratorStatus()` hook already existed specifically for this purpose but wasn't being used. Now both consumers use the shared hook, ensuring consistent staleTime/gcTime and eliminating config drift.

### 2. Fix care history images (S3Image support)
`CareHistoryTimeline` rendered care photos using raw `next/image` with legacy URL strings. If those URLs are CloudFront-served (which they are for S3-migrated images), they require signed-cookie auth that only `S3Image` handles. Updated to:
- Prefer `s3ImageKeys` → `S3Image` component (with thumbnail support)
- Fall back to legacy `images` URLs with `shouldUnoptimizeImage()` for CloudFront detection

### 3. Remove deprecated prop
`CareHistoryTimeline` had a `plantInstance` prop marked `@deprecated` that was never read. Removed the prop from the interface and the unused pass-through in `PlantDetailModal`.

## Files Changed
- `src/components/navigation/BottomNavigation.tsx` — use `useCuratorStatus()`
- `src/app/dashboard/DashboardClient.tsx` — use `useCuratorStatus()`
- `src/components/care/CareHistoryTimeline.tsx` — S3Image support, remove deprecated prop
- `src/components/plants/PlantDetailModal.tsx` — stop passing unused prop

## Checks
- ✅ `npx tsc --noEmit` — no type errors
- ✅ `npm run lint` — clean